### PR TITLE
Showing Private IP Address when listing EC2 instances, allowing to use Private IP address when connecting to EC2 instance or do port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,20 @@ $ aws-remote --profile my_profile --region us-west-2 port-forward 8080 80 instan
 
 2. Install script packages:
 `pip install -r aws-remote/requirements.txt`
+  or
+`pip3 install -r aws-remote/requirements.txt`
 
 5. Verify script works: 
 `python3 aws-remote/aws-remote --help`
 
-6. If desired, add alias to bash_profile and then restart terminal:
+6a. BASH: If desired, add alias to bash_profile and then restart terminal:
 ```
 vi ~/.bash_profile
+alias aws-remote='python3 ~/your-script-directory/aws-remote/aws-remote'
+```
+
+6b. ZSH: If desired, add alias to zprofile and then restart terminal:
+```
+vi ~/.zprofile
 alias aws-remote='python3 ~/your-script-directory/aws-remote/aws-remote'
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AWS Remote is a command line tool to view and interact with AWS instances via SS
 - AWS CLI Session Manager Plugin (https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 
 ### What Can It Do?
-aws-remote will list all your EC2 instances in the specified account/region, and display helpful information like state and SSM management status. aws-remote is also a wrapper for the AWS CLI that makes starting remote sessions and port-forwarding easier. Remote sessions and port-forwarding can be started using the EC2 Instance ID or the friendly name.
+aws-remote will list all your EC2 instances in the specified account/region, and display helpful information like state and SSM management status. aws-remote is also a wrapper for the AWS CLI that makes starting remote sessions and port-forwarding easier. Remote sessions and port-forwarding can be started using the EC2 Instance ID or the friendly name or Private IP address.
 
 Examples:
 
@@ -25,18 +25,20 @@ Options:
 
 Commands:
   list          List EC2 instances and SSM management status
-  port-forward  Start SSM port forward to instance id/name
-  session       Start SSM session with instance id/name
+  port-forward  Start SSM port forward to instance id/name/private ip
+  session       Start SSM session with instance id/name/private ip
 
 $ aws-remote list
-ID                     AZ            Type         State      SSM     Name         
-i-01234567890987654    us-east-1a    r4.xlarge    running    true    instance1-example.domain.com
-i-02345678909876543    us-east-1b    t3.micro     running    false   instance2-example.domain.com       
-i-03456789098765432    us-east-1c    t3.medium    running    true    instance3-example.domain.com
+ID                     AZ            Type         State      SSM     IP                Name      
+i-01234567890987654    us-east-1a    r4.xlarge    running    true    192.168.1.1       instance1-example.domain.com
+i-02345678909876543    us-east-1b    t3.micro     running    false   192.168.1.2       instance2-example.domain.com       
+i-03456789098765432    us-east-1c    t3.medium    running    true    192.168.1.3       instance3-example.domain.com
 
 $ aws-remote --profile my_profile session i-02345678909876543
 
 $ aws-remote --profile my_profile session instance2-example.domain.com
+
+$ aws-remote --profile my_profile session 192.168.1.2
 
 $ aws-remote --profile my_profile --region us-west-2 port-forward 8080 80 instance2-example.domain.com
 ```

--- a/aws-remote
+++ b/aws-remote
@@ -23,16 +23,28 @@ def find_instance_id(instance_id, aws_profile, aws_region):
     """
     if str(instance_id).startswith('i-'):
         return instance_id
-    else:
+        else:
+        print(f'Finding instance_id for {instance_id}...')
         try:
-            print(f'Finding instance_id for {instance_id}...')
             boto_session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
             ec2_client = boto_session.client('ec2')
-            instance_filter = [{
+            instance_filter_name = [{
                 'Name': 'tag:Name',
                 'Values': [instance_id]
             }]
-            ec2_instance = ec2_client.describe_instances(Filters=instance_filter)
+            ec2_instance = ec2_client.describe_instances(Filters=instance_filter_name)
+            instance_id = ec2_instance['Reservations'][0]['Instances'][0]['InstanceId']
+            print(f'Found {instance_id}')
+        except Exception:
+            pass
+        try:
+            boto_session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
+            ec2_client = boto_session.client('ec2')
+            instance_filter_privateip = [{
+                'Name': 'private-ip-address',
+                'Values': [instance_id]
+            }]
+            ec2_instance = ec2_client.describe_instances(Filters=instance_filter_privateip)
             instance_id = ec2_instance['Reservations'][0]['Instances'][0]['InstanceId']
             print(f'Found {instance_id}')
         except Exception as e:

--- a/aws-remote
+++ b/aws-remote
@@ -35,6 +35,7 @@ def find_instance_id(instance_id, aws_profile, aws_region):
             ec2_instance = ec2_client.describe_instances(Filters=instance_filter_name)
             instance_id = ec2_instance['Reservations'][0]['Instances'][0]['InstanceId']
             print(f'Found {instance_id}')
+            return instance_id
         except Exception:
             pass
         try:

--- a/aws-remote
+++ b/aws-remote
@@ -67,13 +67,14 @@ def list_instances(ctx):
         ec2_instances = ec2_client.describe_instances()
         ssm_instances = ssm_client.describe_instance_information()['InstanceInformationList']
         print(even_spaces('ID', spaces=22), even_spaces('AZ'), even_spaces('Type'),
-              even_spaces('State', spaces=10), even_spaces('SSM', spaces=8), even_spaces('Name'))
+              even_spaces('State', spaces=10), even_spaces('SSM', spaces=8), even_spaces('IP', spaces=17), even_spaces('Name'))
         for instance in ec2_instances['Reservations']:
             instance = instance['Instances'][0]
             instance_id = instance['InstanceId']
             instance_type = instance['InstanceType']
             instance_az = instance['Placement']['AvailabilityZone']
             instance_state = instance['State']['Name']
+            instance_ip = instance['PrivateIpAddress']
             instance_name = ''
             if 'Tags' in instance:
                 for tag in instance['Tags']:
@@ -82,7 +83,8 @@ def list_instances(ctx):
             instance_managed = str(any(instance_id in ssm_instance['InstanceId'] for ssm_instance in ssm_instances)).lower()
             print(even_spaces(instance_id, spaces=22), even_spaces(instance_az),
                   even_spaces(instance_type), even_spaces(instance_state, spaces=10),
-                  even_spaces(instance_managed, spaces=8), even_spaces(instance_name))
+                  even_spaces(instance_managed, spaces=8), even_spaces(instance_ip, spaces=17),
+                  even_spaces(instance_name))
     except Exception as e:
         print(str(e))
 


### PR DESCRIPTION
- Adding Private IP address column to the list.
- Reverse Instance_ID lookup from Private IP address function.
- Updating README.md to reflect the new functionality.